### PR TITLE
Implementing cache-control config

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -38,6 +38,7 @@ const app = localWebServer({
   log: {
     format: options.server['log-format']
   },
+  cacheControl: options.server.cacheControl,
   compress: options.server.compress,
   mime: options.server.mime,
   forbid: options.server.forbid,

--- a/lib/local-web-server.js
+++ b/lib/local-web-server.js
@@ -38,6 +38,7 @@ function localWebServer (options) {
   options = Object.assign({
     static: {},
     serveIndex: {},
+    cacheControl: {},
     spa: null,
     log: {},
     compress: false,
@@ -116,6 +117,13 @@ function localWebServer (options) {
     const etag = require('koa-etag')
     app.use(conditional())
     app.use(etag())
+  }
+
+  /* cache-control headers */
+  if (options.cacheControl) {
+    const cacheControl = require('koa-cache-control')
+    debug('Cache control', JSON.stringify(options.cacheControl))
+    app.use(cacheControl(options.cacheControl))
   }
 
   /* mime-type overrides */

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "kcors": "^1.1.0",
     "koa": "^2.0.0",
     "koa-bodyparser": "^3.0.0",
+    "koa-cache-control": "^1.0.0",
     "koa-compress": "^1.0.9",
     "koa-conditional-get": "^1.0.3",
     "koa-connect-history-api-fallback": "^0.3.0",


### PR DESCRIPTION
For now, we only have option for disabling cache. Although it is useful, sometimes we'd like to test how does our app performs with some cached files.
I suggest using [koa-cache-control](https://github.com/DaMouse404/koa-cache-control), as it is easy to implement and to set `maxAge` and other headers for local development needs.
