### PR TITLE
Implementing livereload

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -45,6 +45,7 @@ const app = localWebServer({
   'no-cache': options.server['no-cache'],
   rewrite: options.server.rewrite,
   verbose: options.server.verbose,
+  livereload: options.server.livereload,
   mocks: options.server.mocks
 })
 

--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -49,6 +49,10 @@ module.exports = {
       description: 'Verbose output, useful for debugging.', group: 'server'
     },
     {
+      name: 'livereload', type: Boolean,
+      description: 'Use livereload middleware.', group: 'server'
+    },
+    {
       name: 'help', alias: 'h', type: Boolean,
       description: 'Print these usage instructions.', group: 'misc'
     },

--- a/lib/local-web-server.js
+++ b/lib/local-web-server.js
@@ -174,6 +174,12 @@ function localWebServer (options) {
     }))
   }
 
+  /* Livereload */
+  if (options.livereload) {
+    const livereload = require('koa-livereload')
+    app.use(livereload())
+  }
+
   /* serve static files */
   if (options.static.root) {
     const serve = require('koa-static')

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "koa-convert": "^1.2.0",
     "koa-etag": "^2.1.1",
     "koa-json": "^1.1.1",
+    "koa-livereload": "^0.1.23",
     "koa-morgan": "^1.0.1",
     "koa-rewrite": "^2.1.0",
     "koa-route": "^3",


### PR DESCRIPTION
Yet another feature I suggest to use is [koa-livereload](https://github.com/yosuke-furukawa/koa-livereload). I've tested it with [gulp-livereload](https://github.com/vohof/gulp-livereload) and it works, performing page reload when some of watched files changes.

It would be nice to pass into `options`not only `Boolean` flag, but also config for custom livereload port (as it can be passed), although this is not commonly used, as we usually have only one livereload instance running at the same time.

And another option, `excludes`, is important too in order not to inject livereload script into some partials where it might be undesirable. I'm currently trying to find out a way to deal with such troubles.
