### PR TITLE
Add type and main fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "ws": "./bin/cli.mjs"
   },
   "exports": "./index.mjs",
+  "type": "module",
+  "main": "./index.mjs",
   "license": "MIT",
   "keywords": [
     "dev",


### PR DESCRIPTION
Rationale is that this appears to resolve usage via ts-node.